### PR TITLE
メッセージ送信機能を非同期通信に変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.tabSize": 2
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "editor.renderWhitespace": "all",
+  "files.autoSave": "onFocusChange"
 }

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,9 +256,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -305,7 +302,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sprockets
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
+
 //= require_tree .

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -2,55 +2,54 @@ $(function(){
   function buildHTML(message) {
     if (message.text && message.image) {
 			var html = `<div class="chat-main__messages_message">
-										<div class="chat-main__messages__message__upper-info">
-											<div class="chat-main__messages__message__upper-info__talker">
-											${message.user_name}
-											</div>
-											<div class="chat-main__messages__message__upper-info__data">
-											${message.created_at}
-											</div>
-										</div>
-										<div class="chat-main__messages__message__lower-info">
-											<p class="chat-main__messages__message__lower-info__text">
-											${message.text}
-											</p>
-											<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
-										</div>
-									</div>`
+				<div class="chat-main__messages__message__upper-info">
+				<div class="chat-main__messages__message__upper-info__talker">
+				${message.user_name}
+				</div>
+				<div class="chat-main__messages__message__upper-info__data">
+				${message.created_at}
+				</div>
+				</div>
+				<div class="chat-main__messages__message__lower-info">
+				<p class="chat-main__messages__message__lower-info__text">
+				${message.text}
+				</p>
+				<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
+				</div>
+				</div>`
     } else if (message.text) {
 			var html = `<div class="chat-main__messages_message">
-										<div class="chat-main__messages__message__upper-info">
-											<div class="chat-main__messages__message__upper-info__talker">
-											${message.user_name}
-											</div>
-											<div class="chat-main__messages__message__upper-info__data">
-											${message.created_at}
-											</div>
-										</div>
-										<div class="chat-main__messages__message__lower-info">
-											<p class="chat-main__messages__message__lower-info__text">
-											${message.text}
-											</p>
-										</div>
-									</div>`
+				<div class="chat-main__messages__message__upper-info">
+				<div class="chat-main__messages__message__upper-info__talker">
+				${message.user_name}
+				</div>
+				<div class="chat-main__messages__message__upper-info__data">
+				${message.created_at}
+				</div>
+				</div>
+				<div class="chat-main__messages__message__lower-info">
+				<p class="chat-main__messages__message__lower-info__text">
+				${message.text}
+				</p>
+				</div>
+				</div>`
     } else if (message.image) {
 			var html = `<div class="chat-main__messages_message">
-										<div class="chat-main__messages__message__upper-info">
-											<div class="chat-main__messages__message__upper-info__talker">
-											${message.user_name}
-											</div>
-											<div class="chat-main__messages__message__upper-info__data">
-											${message.created_at}
-											</div>
-										</div>
-										<div class="chat-main__messages__message__lower-info">
-											<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
-										</div>
-									</div>`
+				<div class="chat-main__messages__message__upper-info">
+				<div class="chat-main__messages__message__upper-info__talker">
+				${message.user_name}
+				</div>
+				<div class="chat-main__messages__message__upper-info__data">
+				${message.created_at}
+				</div>
+				</div>
+				<div class="chat-main__messages__message__lower-info">
+				<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
+				</div>
+				</div>`
     };
     return html;
-  }
-
+	}
   $("#new_message").on("submit", function(e){
 		e.preventDefault();
 		var formData = new FormData(this);

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,0 +1,77 @@
+$(function(){
+	function buildHTML(message) {
+    if (message.text && message.image) {
+			var html = `<div class="chat-main__messages_message">
+										<div class="chat-main__messages__message__upper-info">
+											<div class="chat-main__messages__message__upper-info__talker">
+											${message.user_name}
+											</div>
+											<div class="chat-main__messages__message__upper-info__data">
+											${message.created_at}
+											</div>
+										</div>
+										<div class="chat-main__messages__message__lower-info">
+											<p class="chat-main__messages__message__lower-info__text">
+											${message.text}
+											</p>
+											<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
+										</div>
+									</div>`
+    } else if (message.text) {
+			var html = `<div class="chat-main__messages_message">
+										<div class="chat-main__messages__message__upper-info">
+											<div class="chat-main__messages__message__upper-info__talker">
+											${message.user_name}
+											</div>
+											<div class="chat-main__messages__message__upper-info__data">
+											${message.created_at}
+											</div>
+										</div>
+										<div class="chat-main__messages__message__lower-info">
+											<p class="chat-main__messages__message__lower-info__text">
+											${message.text}
+											</p>
+										</div>
+									</div>`
+    } else if (message.image) {
+			var html = `<div class="chat-main__messages_message">
+										<div class="chat-main__messages__message__upper-info">
+											<div class="chat-main__messages__message__upper-info__talker">
+											${message.user_name}
+											</div>
+											<div class="chat-main__messages__message__upper-info__data">
+											${message.created_at}
+											</div>
+										</div>
+										<div class="chat-main__messages__message__lower-info">
+											<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
+										</div>
+									</div>`
+    };
+    return html;
+  }
+
+  $("#new_message").on("submit", function(e){
+		e.preventDefault();
+		var formData = new FormData(this);
+		var url = $(this).attr("action");
+		$.ajax({
+			url: url,
+			type: "POST",
+			data: formData,
+			dataType: "json",
+			processData: false,
+			contentType: false
+		})
+		.done(function(data){
+			var html = buildHTML(data);
+			$('.chat-main__messages').append(html);
+			$('.chat-main__messages').animate({ scrollTop: $('.chat-main__messages')[0].scrollHeight});
+			$('form')[0].reset();
+			$('.chat-main__form__form-parents__send-btn').prop('disabled', false);
+		})
+		.fail(function(){
+			alert("メッセージ送信に失敗しました");
+		});
+  });
+});

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,5 +1,5 @@
 $(function(){
-	function buildHTML(message) {
+  function buildHTML(message) {
     if (message.text && message.image) {
 			var html = `<div class="chat-main__messages_message">
 										<div class="chat-main__messages__message__upper-info">

--- a/app/assets/javascripts/messages.js
+++ b/app/assets/javascripts/messages.js
@@ -1,76 +1,79 @@
 $(function(){
   function buildHTML(message) {
     if (message.text && message.image) {
-			var html = `<div class="chat-main__messages_message">
-				<div class="chat-main__messages__message__upper-info">
-				<div class="chat-main__messages__message__upper-info__talker">
-				${message.user_name}
-				</div>
-				<div class="chat-main__messages__message__upper-info__data">
-				${message.created_at}
-				</div>
-				</div>
-				<div class="chat-main__messages__message__lower-info">
-				<p class="chat-main__messages__message__lower-info__text">
-				${message.text}
-				</p>
-				<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
-				</div>
-				</div>`
+      var html = 
+        `<div class="chat-main__messages_message">
+          <div class="chat-main__messages__message__upper-info">
+            <div class="chat-main__messages__message__upper-info__talker">
+              ${message.user_name}
+            </div>
+            <div class="chat-main__messages__message__upper-info__data">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="chat-main__messages__message__lower-info">
+            <p class="chat-main__messages__message__lower-info__text">
+              ${message.text}
+            </p>
+            <img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
+          </div>
+        </div>`
     } else if (message.text) {
-			var html = `<div class="chat-main__messages_message">
-				<div class="chat-main__messages__message__upper-info">
-				<div class="chat-main__messages__message__upper-info__talker">
-				${message.user_name}
-				</div>
-				<div class="chat-main__messages__message__upper-info__data">
-				${message.created_at}
-				</div>
-				</div>
-				<div class="chat-main__messages__message__lower-info">
-				<p class="chat-main__messages__message__lower-info__text">
-				${message.text}
-				</p>
-				</div>
-				</div>`
+      var html = 
+        `<div class="chat-main__messages_message">
+          <div class="chat-main__messages__message__upper-info">
+            <div class="chat-main__messages__message__upper-info__talker">
+              ${message.user_name}
+            </div>
+            <div class="chat-main__messages__message__upper-info__data">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="chat-main__messages__message__lower-info">
+            <p class="chat-main__messages__message__lower-info__text">
+              ${message.text}
+            </p>
+          </div>
+        </div>`
     } else if (message.image) {
-			var html = `<div class="chat-main__messages_message">
-				<div class="chat-main__messages__message__upper-info">
-				<div class="chat-main__messages__message__upper-info__talker">
-				${message.user_name}
-				</div>
-				<div class="chat-main__messages__message__upper-info__data">
-				${message.created_at}
-				</div>
-				</div>
-				<div class="chat-main__messages__message__lower-info">
-				<img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
-				</div>
-				</div>`
-    };
+      var html = 
+        `<div class="chat-main__messages_message">
+          <div class="chat-main__messages__message__upper-info">
+            <div class="chat-main__messages__message__upper-info__talker">
+              ${message.user_name}
+            </div>
+            <div class="chat-main__messages__message__upper-info__data">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="chat-main__messages__message__lower-info">
+            <img src ="${message.image}" class="chat-main__messages__message__lower-info__image">
+          </div>
+        </div>`
+      };
     return html;
-	}
+  }
   $("#new_message").on("submit", function(e){
-		e.preventDefault();
-		var formData = new FormData(this);
-		var url = $(this).attr("action");
-		$.ajax({
-			url: url,
-			type: "POST",
-			data: formData,
-			dataType: "json",
-			processData: false,
-			contentType: false
-		})
-		.done(function(data){
-			var html = buildHTML(data);
-			$('.chat-main__messages').append(html);
-			$('.chat-main__messages').animate({ scrollTop: $('.chat-main__messages')[0].scrollHeight});
-			$('form')[0].reset();
-			$('.chat-main__form__form-parents__send-btn').prop('disabled', false);
-		})
-		.fail(function(){
-			alert("メッセージ送信に失敗しました");
-		});
+  e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.chat-main__messages').append(html);
+      $('.chat-main__messages').animate({ scrollTop: $('.chat-main__messages')[0].scrollHeight});
+      $('form')[0].reset();
+      $('.chat-main__form__form-parents__send-btn').prop('disabled', false);
+    })
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
+    });
   });
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -8,8 +8,10 @@ class MessagesController < ApplicationController
 
   def create
     @message = @group.messages.new(message_params)
-		if @message.save
-			redirect_to group_messages_path(@group), notice:  "メッセージが送信されました"
+    if @message.save
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = "メッセージを入力してください"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,8 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%F %a %R")
+json.text @message.text
+json.image @message.image.url


### PR DESCRIPTION
# what
1. chat-spaceでjQueryが使えるように設定し、jsファイルを作成する
2. フォームが送信されたら、イベントが発火するようにする
3.  2.のイベントが発火したときにAjaxを使用して、messages#createが動くようにする
4. messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
5.  jbuilderを使用して、作成したメッセージをJSON形式で返す
6. 返ってきたJSONをdoneメソッドで受取り、HTMLを作成する
7. 6.で作成したHTMLをメッセージ画面の一番下に追加する
8. メッセージを送信したとき、メッセージ画面を最下部にスクロールする
9. 連続で送信ボタンを押せるようにする
10. 非同期に失敗した場合の処理も準備する

# why
現行の仕様はメッセージを送信するたびに送信画面にリダイレクトされ、ビューが毎回再描画されいるが、このメッセージ送信機能を非同期通信で行うため
[アーカイブ.zip](https://github.com/oznekpark/chat-space/files/4407681/default.zip)



